### PR TITLE
add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+torch
+torchaudio
+tensorboard
+libroso
+einops
+matplotlib
+matplotlib
+pyyaml
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ tensorboard
 libroso
 einops
 matplotlib
-matplotlib
 pyyaml
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 torchaudio
 tensorboard
-libroso
+libroso==0.9.1
 einops
 matplotlib
 pyyaml


### PR DESCRIPTION
Seems missing following libs in python 3.8 environments. so add to requirements.txt.
torch
torchaudio
tensorboard
libroso
einops
matplotlib
pyyaml
tqdm
