### PR TITLE
Fix mel filterbank warning and update alpha calculation

### DIFF
--- a/academicodec/models/soundstream/loss.py
+++ b/academicodec/models/soundstream/loss.py
@@ -71,16 +71,18 @@ def reconstruction_loss(x, G_x, args, eps=1e-7):
         s = 2**i
         melspec = MelSpectrogram(
             sample_rate=args.sr,
-            n_fft=s,
+            n_fft=max(s, 512),
+            win_length=s,
             hop_length=s // 4,
             n_mels=64,
             wkwargs={"device": args.device}).to(args.device)
         S_x = melspec(x)
         S_G_x = melspec(G_x)
-        loss = ((S_x - S_G_x).abs().mean() + (
-            ((torch.log(S_x.abs() + eps) - torch.log(S_G_x.abs() + eps))**2
-             ).mean(dim=-2)**0.5).mean()) / (i)
-        L += loss
+        l1_loss = (S_x - S_G_x).abs().mean()
+        l2_loss = (((torch.log(S_x.abs() + eps) - torch.log(S_G_x.abs() + eps))**2).mean(dim=-2)**0.5).mean()
+
+        alpha = (s / 2) ** 0.5
+        L += (l1_loss + alpha * l2_loss)
         #print('i ,loss ', i, loss)
     #assert 1==2
     return L


### PR DESCRIPTION
This pull request addresses two key issues in the reconstruction_loss function of the AcademiCodec project:

Mel Filterbank Warning: A warning was raised stating that at least one mel filterbank had all zero values, suggesting that the value for n_mels might be set too high, or the value for n_freqs too low. This issue is potentially due to the inappropriate n_fft value. To resolve this, the n_fft parameter in the MelSpectrogram configuration has been modified to be the maximum of 512 and the scale factor s. This change ensures more robust filterbank generation across different scales.

Alpha Calculation in Loss Function: The original implementation did not explicitly include the calculation of α_s = sqrt(s/2) as mentioned in the corresponding paper. This pull request introduces this calculation and incorporates alpha into the loss computation. This adjustment ensures that the loss calculation aligns more closely with the theoretical foundation laid out in the paper.

These modifications aim to enhance the accuracy and reliability of the loss computation. 